### PR TITLE
fix: Removed convertion of path-delimitor to windows-path

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -26,7 +26,6 @@ function build_templatedata_string(options) {
 }
 
 function AMCP_PARAMETER(data) {
-	data = data.replace(/\//g, '\\\\')
 	data = data.replace(/"/g, '\\"')
 
 	if (data.match(/\s/)) {


### PR DESCRIPTION
The function `AMCP_PARAMETER` in [action.js](https://github.com/bitfocus/companion-module-casparcg-server/blob/master/actions.js) replaces a forward slash with a double-backslash / changes from a unix-path to a windows path.

From my testing this is unnecessary / bad:
- casparcg running on windows understands forward slashes
- casparcg running on linux does **not** understand backward slashes and gives errors.

The casparcg-client is always using forward slashes too.
